### PR TITLE
Pin Databricks provider version to v0.2.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,5 @@
 provider "databricks" {
+  version = "0.2.0"
   azure_auth = {
     workspace_name         = var.databricks_workspace.name
     resource_group         = var.databricks_workspace.resource_group_name


### PR DESCRIPTION
Stops new versions of the Databricks provider with some known bugs downloaded on tf init.

Necessary because the Databricks provider was recently added to the Terraform registry.