### PR TITLE
Make notebook deployment optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,3 @@
 
 # OS files
 *.DS_Store
-
-# Notebook files
-*notebooks

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ export ARM_CLIENT_ID="your-client-id"
 export ARM_CLIENT_SECRET="your-client-secret"
 ```
 
-The module also provides the option to deploy a pre-created local [Jupyter notebook](https://jupyter.org/) to the workspace. This can contain any valid Jupyter notebook content. Use of variable `notebook_path` triggers this resource deployment, but as in the minimal example it can be foregone entirely, deploying just the workspace and clusters.
+The module also provides the option to deploy a pre-created local [Jupyter notebook](https://jupyter.org/) to the workspace. This can contain any valid Jupyter notebook content. Use of variable `notebook_path` triggers this resource deployment, but as in the minimal example it can be foregone entirely, deploying just the workspace and clusters. For ease of getting started, an example notebook is provided at `./notebooks/notebook.ipynb`, and the complete example uploads this by default.
 
 ## Providers
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ export ARM_CLIENT_ID="your-client-id"
 export ARM_CLIENT_SECRET="your-client-secret"
 ```
 
-You must also create a local [Jupyter notebook](https://jupyter.org/) for deployment to the workspace. This can contain any valid Jupyter notebook content. To use with the examples out of the box, this should be placed at `./notebooks/notebook.ipynb`, or you can pass in the path to another notebook on your system as variable `notebook_path`.
+The module also provides the option to deploy a pre-created local [Jupyter notebook](https://jupyter.org/) to the workspace. This can contain any valid Jupyter notebook content. Use of variable `notebook_path` triggers this resource deployment, but as in the minimal example it can be foregone entirely, deploying just the workspace and clusters.
 
 ## Providers
 
@@ -62,8 +62,8 @@ You must also create a local [Jupyter notebook](https://jupyter.org/) for deploy
 | prefix | A naming prefix to be used in the creation of unique names for deployed Databricks resources. | `list(string)` | `[]` | no |
 | suffix | A naming suffix to be used in the creation of unique names for deployed Databricks resources. | `list(string)` | `[]` | no |
 | whl\_upload\_script\_path | Path to a bash script which downloads the whls in cluster\_default\_packages, and uploads them to dbfs. | `string` | `""` | no |
-| notebook\_path | Relative path to a local Jupyter notebook to deploy to the workspace. | `string` | n/a | yes |
-| notebook\_name | Desired name of the deployed notebook as it will appear in the workspace. | `string` | `"mynotebook"` | no |
+| notebook\_path | Optional relative path to a local Jupyter notebook to deploy to the workspace. | `string` | "" | no |
+| notebook\_name | If deploying, the desired name of the deployed notebook as it will appear in the workspace. | `string` | `"mynotebook"` | no |
 
 ## Outputs
 

--- a/examples/minimal/main.tf
+++ b/examples/minimal/main.tf
@@ -29,5 +29,4 @@ resource "azurerm_databricks_workspace" "test_ws" {
 module "terraform-databricks-sec-resources" {
   source               = "../../"
   databricks_workspace = azurerm_databricks_workspace.test_ws
-  notebook_path        = "notebooks/notebook.ipynb"
 }

--- a/main.tf
+++ b/main.tf
@@ -79,7 +79,7 @@ resource "databricks_cluster" "high_concurrency_cluster" {
 
 # If notebook_path given, upload local Jupyter notebook on deployment
 resource "databricks_notebook" "notebook" {
-  count     = var.notebook_path=="" ? 0 : 1
+  count     = var.notebook_path == "" ? 0 : 1
   content   = filebase64("${path.module}/${var.notebook_path}")
   path      = "/${var.notebook_name}"
   mkdirs    = true

--- a/main.tf
+++ b/main.tf
@@ -77,8 +77,9 @@ resource "databricks_cluster" "high_concurrency_cluster" {
   depends_on = [time_sleep.wait]
 }
 
-# Upload local Jupyter notebook on deployment
+# If notebook_path given, upload local Jupyter notebook on deployment
 resource "databricks_notebook" "notebook" {
+  count     = var.notebook_path=="" ? 0 : 1
   content   = filebase64("${path.module}/${var.notebook_path}")
   path      = "/${var.notebook_name}"
   mkdirs    = true

--- a/notebooks/notebook.ipynb
+++ b/notebooks/notebook.ipynb
@@ -1,0 +1,1 @@
+{"cells":[{"cell_type":"code","execution_count":null,"metadata":{},"outputs":[],"source":["# Welcome to your Jupyter notebook"]}],"metadata":{"name":"graphbuilder","notebookId":2285445867814993},"nbformat":4,"nbformat_minor":0}

--- a/variables.tf
+++ b/variables.tf
@@ -8,7 +8,7 @@ variable "databricks_workspace" {
 variable "notebook_path" {
   type        = string
   description = "Relative path to a local Jupyter notebook to deploy to the workspace."
-  default = ""
+  default     = ""
 }
 
 variable "cluster_default_packages" {

--- a/variables.tf
+++ b/variables.tf
@@ -3,12 +3,13 @@ variable "databricks_workspace" {
   description = "Databricks workspace to deploy resources to."
 }
 
+# Optional variables
+
 variable "notebook_path" {
   type        = string
   description = "Relative path to a local Jupyter notebook to deploy to the workspace."
+  default = ""
 }
-
-# Optional variables
 
 variable "cluster_default_packages" {
   type        = list(string)


### PR DESCRIPTION
For flexibility, deployment of local Jupyter Notebook to the workspace is now conditional on the use of the "notebook_path" variable, which is now optional.